### PR TITLE
Fix word function strangeness in recent docker

### DIFF
--- a/grep/Dockerfile
+++ b/grep/Dockerfile
@@ -1,3 +1,3 @@
 FROM busybox
 COPY func.sh /func.sh
-CMD /func.sh
+CMD sh /func.sh

--- a/head/Dockerfile
+++ b/head/Dockerfile
@@ -1,3 +1,3 @@
 FROM busybox
 COPY func.sh /func.sh
-CMD /func.sh
+CMD sh /func.sh

--- a/linecount/Dockerfile
+++ b/linecount/Dockerfile
@@ -1,3 +1,3 @@
 FROM busybox
 COPY func.sh /func.sh
-CMD /func.sh
+CMD sh /func.sh


### PR DESCRIPTION
There is some strangeness with running these functions in my docker environment that I'm still getting to the bottom of. In the meantime this PR makes it work.